### PR TITLE
Fix HTML injection of preset dialogs, implement beginning of format selection process

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A powerful SillyTavern extension that dynamically renders visually appealing tra
 - **Macro Integration**: Includes `{{sim_tracker}}` and `{{last_sim_stats}}` macros for prompt engineering
 - **Data Hiding**: Option to hide raw JSON code blocks while keeping the visual cards
 - **Custom Fields Definition**: Define your own data fields for use in templates and prompts
+- **YAML/JSON Format Switching**: Choose between JSON and YAML formats for your tracker blocks with automatic parsing of both formats
 
 ### Template System
 - **Handlebars.js Templates**: Powerful templating engine for creating rich, dynamic cards
@@ -85,6 +86,19 @@ Supports both legacy and modern JSON formats:
     }
   ]
 }
+```
+
+**YAML Format** (alternative):
+```yaml
+worldData:
+  current_date: "2025-08-10"
+  current_time: "14:30"
+characters:
+  - name: "Alice"
+    ap: 75
+    dp: 60
+    tp: 80
+    cp: 20
 ```
 
 ## Usage Examples
@@ -217,5 +231,21 @@ To help users transition to the improved JSON format:
 1. **Settings Button**: Use the "Migrate to New Format" button in the settings panel
 2. **Slash Command**: Type `/sst-convert` in any chat to migrate all data in that chat
 3. **Automatic Compatibility**: Both old and new formats are supported seamlessly
+
+## Slash Commands
+
+### /sst-convert
+Converts all sim data in the current chat from the old format to the new format.
+
+**Usage:**
+- `/sst-convert` - Converts all sim data to the new format using current settings
+- `/sst-convert json` - Converts all sim data to JSON format
+- `/sst-convert yaml` - Converts all sim data to YAML format
+
+### /sst-add
+Adds a sim block to the last character message if it doesn't already have one, and requests continuation.
+
+**Usage:**
+- `/sst-add` - Adds a sim block in the user's preferred format (JSON or YAML)
 
 ---

--- a/formatUtils.js
+++ b/formatUtils.js
@@ -27,8 +27,7 @@ const parseYaml = (yamlContent) => {
   try {
     // This is a simplified YAML parser for our specific use case
     // A full implementation would use a library like js-yaml
-    const lines = yamlContent.trim().split('
-');
+    const lines = yamlContent.trim().split('');
     const result = {};
     let currentObject = result;
     const stack = [result];

--- a/formatUtils.js
+++ b/formatUtils.js
@@ -1,0 +1,263 @@
+// formatUtils.js - Format detection, parsing, and generation utilities
+import { get_extension_directory } from "./utils.js";
+
+const MODULE_NAME = "silly-sim-tracker";
+
+// --- FORMAT UTILITIES ---
+const log = (message) => console.log(`[SST] [${MODULE_NAME}]`, message);
+
+// Function to detect the format of a tracker block
+const detectFormat = (content) => {
+  // Trim whitespace
+  const trimmedContent = content.trim();
+  
+  // Try to detect JSON format (starts with { or [)
+  if ((trimmedContent.startsWith("{") && trimmedContent.endsWith("}")) || 
+      (trimmedContent.startsWith("[") && trimmedContent.endsWith("]"))) {
+    return "json";
+  }
+  
+  // If it doesn't start with { or [, it might be YAML
+  // We'll assume YAML for non-JSON content for now
+  return "yaml";
+};
+
+// Improved function to parse YAML content
+const parseYaml = (yamlContent) => {
+  try {
+    // This is a simplified YAML parser for our specific use case
+    // A full implementation would use a library like js-yaml
+    const lines = yamlContent.trim().split('
+');
+    const result = {};
+    let currentObject = result;
+    const stack = [result];
+    let inArray = false;
+    let currentArray = null;
+    let currentArrayParent = null;
+    
+    lines.forEach(line => {
+      // Skip empty lines and comments
+      if (!line.trim() || line.trim().startsWith('#')) return;
+      
+      // Calculate indentation level
+      const indent = line.search(/\S/);
+      const trimmedLine = line.trim();
+      
+      // Handle array items (lines starting with -)
+      if (trimmedLine.startsWith('- ')) {
+        // This is an array item
+        if (!inArray) {
+          // Start a new array
+          inArray = true;
+          currentArray = [];
+          // Add array to parent
+          const parent = stack[stack.length - 1];
+          // Find the key that should contain this array
+          // This is a simplification - in real YAML the array would be associated with a key
+          // For our purposes, we'll assume it's for the characters field
+          parent.characters = currentArray;
+        }
+        
+        // Extract the content after "- "
+        const itemContent = trimmedLine.substring(2).trim();
+        
+        // Check if it's a nested object
+        if (itemContent.endsWith(':')) {
+          // This is a nested object in the array
+          const newItem = {};
+          currentArray.push(newItem);
+          stack.push(newItem);
+        } else if (itemContent.includes(':')) {
+          // This is a key-value pair in an array item
+          // For simplicity, we'll create a new object for this array item if we don't have one
+          if (currentArray.length === 0 || typeof currentArray[currentArray.length - 1] !== 'object') {
+            const newItem = {};
+            if (currentArray.length > 0 && typeof currentArray[currentArray.length - 1] !== 'object') {
+              // Replace the last item if it was a simple value
+              currentArray.pop();
+            }
+            currentArray.push(newItem);
+            stack.push(newItem);
+          }
+          
+          const currentArrayItem = stack[stack.length - 1];
+          const parts = itemContent.split(':');
+          const key = parts[0].trim().replace(/["']/g, '');
+          const value = parts.slice(1).join(':').trim();
+          
+          // Handle different value types
+          if (value === 'true' || value === 'false') {
+            currentArrayItem[key] = value === 'true';
+          } else if (!isNaN(value) && value !== '') {
+            currentArrayItem[key] = Number(value);
+          } else {
+            currentArrayItem[key] = value.replace(/["']/g, '');
+          }
+        } else {
+          // Simple value in array
+          currentArray.push(itemContent);
+        }
+        return;
+      }
+      
+      // If we were in an array and now have a regular key, exit array mode
+      if (inArray && !trimmedLine.startsWith('- ')) {
+        inArray = false;
+        // Pop array items from stack if needed
+        while (stack.length > (indent / 2) + 1) {
+          stack.pop();
+        }
+      }
+      
+      // Adjust stack based on indentation
+      while (stack.length > (indent / 2) + 1) {
+        stack.pop();
+      }
+      
+      // Get current object at this indentation level
+      currentObject = stack[stack.length - 1];
+      
+      // Parse key-value pairs
+      if (trimmedLine.includes(':')) {
+        const parts = trimmedLine.split(':');
+        const key = parts[0].trim().replace(/["']/g, '');
+        const value = parts.slice(1).join(':').trim();
+        
+        // Handle nested objects
+        if (value === '') {
+          const newObject = {};
+          currentObject[key] = newObject;
+          stack.push(newObject);
+        } else {
+          // Handle different value types
+          if (value === 'true' || value === 'false') {
+            currentObject[key] = value === 'true';
+          } else if (!isNaN(value) && value !== '') {
+            currentObject[key] = Number(value);
+          } else {
+            currentObject[key] = value.replace(/["']/g, '');
+          }
+        }
+      }
+    });
+    
+    return result;
+  } catch (error) {
+    log(`Error parsing YAML content: ${error.message}`);
+    throw error;
+  }
+};
+
+// Function to convert JSON to YAML
+const convertJsonToYaml = (jsonObject, indent = 0) => {
+  let yaml = '';
+  const indentStr = '  '.repeat(indent);
+  
+  if (typeof jsonObject === 'object' && jsonObject !== null) {
+    if (Array.isArray(jsonObject)) {
+      jsonObject.forEach(item => {
+        if (typeof item === 'object' && item !== null) {
+          yaml += `${indentStr}-\n${convertJsonToYaml(item, indent + 1)}`;
+        } else {
+          yaml += `${indentStr}- ${convertValueToYaml(item)}\n`;
+        }
+      });
+    } else {
+      Object.keys(jsonObject).forEach(key => {
+        const value = jsonObject[key];
+        if (typeof value === 'object' && value !== null) {
+          if (Array.isArray(value)) {
+            yaml += `${indentStr}${key}:\n`;
+            yaml += convertJsonToYaml(value, indent + 1);
+          } else {
+            yaml += `${indentStr}${key}:\n`;
+            yaml += convertJsonToYaml(value, indent + 1);
+          }
+        } else {
+          yaml += `${indentStr}${key}: ${convertValueToYaml(value)}\n`;
+        }
+      });
+    }
+  }
+  
+  return yaml;
+};
+
+// Helper function to convert a value to its YAML representation
+const convertValueToYaml = (value) => {
+  if (typeof value === 'string') {
+    // Check if string needs quotes
+    if (value.includes(':') || value.includes('#') || /\s/.test(value)) {
+      return `"${value}"`;
+    }
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  return String(value);
+};
+
+// Universal parser that can handle both JSON and YAML
+const parseTrackerData = (content, format = null) => {
+  try {
+    // Detect format if not specified
+    if (!format) {
+      format = detectFormat(content);
+    }
+    
+    if (format === "json") {
+      return JSON.parse(content);
+    } else if (format === "yaml") {
+      return parseYaml(content);
+    } else {
+      throw new Error(`Unsupported format: ${format}`);
+    }
+  } catch (error) {
+    log(`Error parsing tracker data: ${error.message}`);
+    throw error;
+  }
+};
+
+// Function to generate tracker block in the specified format
+const generateTrackerBlock = (data, format, identifier) => {
+  try {
+    if (format === "json") {
+      return `\`\`\`${identifier}\n${JSON.stringify(data, null, 2)}\n\`\`\``;
+    } else if (format === "yaml") {
+      const yamlContent = convertJsonToYaml(data);
+      return `\`\`\`${identifier}\n${yamlContent}\`\`\``;
+    } else {
+      throw new Error(`Unsupported format: ${format}`);
+    }
+  } catch (error) {
+    log(`Error generating tracker block: ${error.message}`);
+    throw error;
+  }
+};
+
+// Function to convert between formats
+const convertTrackerFormat = (content, targetFormat, identifier) => {
+  try {
+    // Parse the content regardless of its current format
+    const data = parseTrackerData(content);
+    
+    // Generate in the target format
+    return generateTrackerBlock(data, targetFormat, identifier);
+  } catch (error) {
+    log(`Error converting tracker format: ${error.message}`);
+    throw error;
+  }
+};
+
+// Export functions
+export {
+  detectFormat,
+  parseYaml,
+  convertJsonToYaml,
+  convertValueToYaml,
+  parseTrackerData,
+  generateTrackerBlock,
+  convertTrackerFormat
+};

--- a/settings.html
+++ b/settings.html
@@ -103,6 +103,18 @@
           If enabled, the raw sim JSON code blocks will be hidden from the chat display, but the tracker cards will still be generated.
         </p>
         <hr />
+        
+        <div class="setting">
+          <label for="trackerFormat">Tracker Format</label>
+          <select id="trackerFormat" class="text_pole">
+            <option value="json">JSON</option>
+            <option value="yaml">YAML</option>
+          </select>
+        </div>
+        <p class="description">
+          Choose the format for generated tracker blocks. Both JSON and YAML formats are supported.
+        </p>
+        <hr />
 
         <div class="setting">
           <label for="datingSimPrompt">Sim Tracker System Prompt</label>

--- a/settingsHandler.js
+++ b/settingsHandler.js
@@ -82,6 +82,7 @@ const default_settings = {
   customFields: [...defaultSimFields], // Clone the default fields
   hideSimBlocks: true, // New setting to hide sim blocks in message text
   userPresets: [], // New setting to store user presets
+  trackerFormat: "json", // New setting for tracker format (json or yaml)
 };
 
 let settings = {};
@@ -225,6 +226,7 @@ const initialize_settings_listeners = (
   bind_setting("#defaultBgColor", "defaultBgColor", "color");
   bind_setting("#showThoughtBubble", "showThoughtBubble", "boolean");
   bind_setting("#hideSimBlocks", "hideSimBlocks", "boolean"); // New setting
+  bind_setting("#trackerFormat", "trackerFormat", "text"); // New setting
   bind_setting("#datingSimPrompt", "datingSimPrompt", "textarea");
 
   // Listener for the default template dropdown

--- a/settingsHandler.js
+++ b/settingsHandler.js
@@ -349,21 +349,21 @@ const initialize_settings_listeners = (
     }
   });
 
-  // Listener for preset export button
+  // Handle preset export
   $("#exportPresetBtn").on("click", () => {
     handlePresetExport(loadTemplate, refreshAllCards);
   });
 
-  // Listener for preset import button
+  // Handle preset import
   $("#importPresetBtn").on("click", () => {
-    $("#presetImportInput").click(); // Trigger the hidden file input
+    $("#presetImportInput").click();
   });
-
+  
   $("#presetImportInput").on("change", (event) => {
     handlePresetImport(event, loadTemplate, refreshAllCards);
   });
 
-  // Listener for manage presets button
+  // Handle manage presets
   $("#managePresetsBtn").on("click", () => {
     showManagePresetsModal(loadTemplate, refreshAllCards);
   });


### PR DESCRIPTION
HTML injection methods previously used erroneously dropped the preset management windows and dialog into the extension drawer

The guts for JSON/YAML selectable format are now implemented into main.